### PR TITLE
Stop auto-expanding the top standings row

### DIFF
--- a/src/features/standings/HeatTable.tsx
+++ b/src/features/standings/HeatTable.tsx
@@ -103,8 +103,7 @@ export default function HeatTable({
     const dir = "asc";
     setSorted({ key: key, dir: dir });
     setPage(1);
-    const first = source[0];
-    setExpanded(first ? `${first.id}_${first.year}` : "");
+    setExpanded("");
   }, [mode.by, source]);
 
   const total = coaches.length;


### PR DESCRIPTION
## Summary
- Remove the HeatTable behavior that auto-expanded the first coach row whenever filters/source refreshed.
- Rows now stay collapsed on load and after filter changes; expansion is click-only.

## Test plan
- [ ] Load standings — no row is expanded by default
- [ ] Change year / team / heat filters — table updates, still no auto-expand
- [ ] Click a row to expand/collapse — still works as before


Made with [Cursor](https://cursor.com)