### PR TITLE
Wake What-If API on page load

### DIFF
--- a/src/features/what-if/WhatIf.tsx
+++ b/src/features/what-if/WhatIf.tsx
@@ -11,6 +11,7 @@ interface Props {
 }
 
 const HISTORY_LIMIT = 3;
+const PREDICT_URL = "https://coaches-svfw.onrender.com/predict";
 
 function sameSnapshot(
   a: WhatIfSnapshot,
@@ -80,7 +81,7 @@ export default function WhatIf({ source }: Props) {
     const startTime = Date.now();
     const id = ++requestId.current;
 
-    fetch("https://coaches-svfw.onrender.com/predict", {
+    fetch(PREDICT_URL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/layout/Layout.astro
+++ b/src/layout/Layout.astro
@@ -36,6 +36,13 @@ const siteUrl = "https://hot-seat.netlify.app";
 
     <link rel="icon" href="/favicon.ico" />
     <title>{title}</title>
+    {/* Wake the Render What-If API on first paint so a cold start can finish before the user interacts. */}
+    <script is:inline>
+      fetch("https://coaches-svfw.onrender.com/", {
+        mode: "no-cors",
+        keepalive: true,
+      }).catch(() => {});
+    </script>
   </head>
   <body class="px-2 antialiased text-white bg-neutral-800 sm:px-8">
     <Header />


### PR DESCRIPTION
## Summary
- Ping the Render What-If API (`coaches-svfw`) on first paint so cold starts can begin before the user opens What If
- Fire-and-forget request (`no-cors`, ignore result); extract predict URL constant in `WhatIf.tsx`

## Test plan
- [ ] Load the site with the API spun down (or after 15+ min idle) and confirm Network shows a request to `coaches-svfw.onrender.com`
- [ ] Wait ~30–60s, then change a What If record/round and confirm predict feels faster than a cold first click
- [ ] Confirm What If predictions still return normally when the API is already warm


Made with [Cursor](https://cursor.com)